### PR TITLE
fix: Bugfix for crash when cache dir doesn't exist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,15 +26,17 @@ function getHashCode(key: string): string {
 
 export class FileStore {
     constructor() {
-        try {
-            fs.stat("cache")
-        } catch (error) {
-            const err = error as any
-            if (err.code === "ENOENT") {
-                fs.mkdir("cache")
+        (async () => {
+            try {
+                await fs.stat("cache")
+            } catch (e) {
+                const err = e as any
+                console.log(e.message)
+                if (err.code === "ENOENT") {
+                    await fs.mkdir("cache")
+                }
             }
-            console.error(error)
-        }
+        })()
     }
     async getItem(key: string) {
         console.log(key)


### PR DESCRIPTION
Quashed an annoying bug which caused the node app to crash with a triggerUncaughtException when the cache dir didn't exist.
IIAFE was pretty much the only non-breaking solution since we need away to prepare the filesystem async in the constructor.