### PR TITLE
fix: Clear cache dir even if there are cached files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export class FileStore {
     }
 
     async clear() {
-        await fs.rmdir("cache")
+        await fs.rm("cache", {recursive: true, force: true})
     }
 
     async length(): Promise<number> {


### PR DESCRIPTION
Clear cache dir even if there are cached files using `fs.rm()` with `recursive: true`.

We'll need to set `adapter.clearOnError = true` if we want to retain the cache.