### PR TITLE
chore: Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,16 +30,16 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "@types/node": "^14.0",
-    "@typescript-eslint/eslint-plugin": "^2.30.0",
-    "@typescript-eslint/parser": "^2.30.0",
-    "eslint": "^6.8.0",
+    "@types/node": "^17.0",
+    "@typescript-eslint/eslint-plugin": "^5.0",
+    "@typescript-eslint/parser": "^5.0",
+    "eslint": "^8.0",
     "eslint-config-google": "^0.14.0",
-    "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-sonarjs": "^0.5.0",
+    "eslint-plugin-import": "^2.0",
+    "eslint-plugin-sonarjs": "^0.11.0",
     "rimraf": "^3.0",
-    "ts-node": "^8.8.2",
-    "typescript": "^3.2.2"
+    "ts-node": "^10.0",
+    "typescript": "^4.0"
   },
   "main": "lib/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export class FileStore {
                 await fs.stat("cache")
             } catch (e) {
                 const err = e as any
-                console.log(e.message)
+                console.log(err.message)
                 if (err.code === "ENOENT") {
                     await fs.mkdir("cache")
                 }


### PR DESCRIPTION
Updated dependencies including update to TS 4.0
TS 4.0 treats catch clause variable as `unknown` instead of `any`, so fixed errors due to that as well.